### PR TITLE
Fix encryption so that API doesn't return sign/HMAC errors

### DIFF
--- a/src/Crypto/Sha256.ts
+++ b/src/Crypto/Sha256.ts
@@ -22,12 +22,9 @@ export const stringToHash = async (string: string) => {
  * @returns {Promise<string>}
  */
 export const encryptString = async (data: string, publicKey: any, raw: boolean = false): Promise<string | any> => {
-    // create a new message digest for our string
-    const messageDigest = forgeSha256.create();
-    messageDigest.update(data, "raw");
 
-    // sign it with a private key
-    const signatureBytes = publicKey.encrypt(messageDigest.digest().getBytes());
+    // sign it with a server's public key
+    const signatureBytes = publicKey.encrypt(data);
 
     if (raw) return signatureBytes;
 

--- a/src/Crypto/Sha256.ts
+++ b/src/Crypto/Sha256.ts
@@ -22,7 +22,6 @@ export const stringToHash = async (string: string) => {
  * @returns {Promise<string>}
  */
 export const encryptString = async (data: string, publicKey: any, raw: boolean = false): Promise<string | any> => {
-
     // sign it with a server's public key
     const signatureBytes = publicKey.encrypt(data);
 

--- a/src/HTTP/EncryptRequestHandler.ts
+++ b/src/HTTP/EncryptRequestHandler.ts
@@ -32,14 +32,14 @@ export default class EncryptRequestHandler {
         const body = JSON.stringify(request.requestConfig.data);
 
         const iv = forge.random.getBytesSync(16);
-        const key = forge.random.getBytesSync(16);
+        const key = forge.random.getBytesSync(32);
 
         const encryptedAesKey = await encryptString(key, this.Session.serverPublicKey, true);
         const encryptedBody: string = this.getEncryptedBody(key, iv, body);
         const hmacBytes: string = this.getBodyHmac(key, iv, encryptedBody);
 
         // set new body
-        request.setData(encryptedBody);
+        request.setData(Buffer.from(encryptedBody, "binary"));
 
         // disable request transform
         request.setOptions("transformRequest", (data: any, headers: any) => {

--- a/src/HTTP/SignRequestHandler.ts
+++ b/src/HTTP/SignRequestHandler.ts
@@ -57,8 +57,8 @@ export default class SignRequestHandler {
 
             request.setData(requestData);
         } else if (options.isEncrypted) {
-            const requestData: string = request.data;
-            data = requestData;
+            const requestData: Buffer = request.data;
+            data = requestData.toString('binary');
 
             request.setData(requestData);
         } else if (appendDataWhitelist.some(item => item === request.method)) {

--- a/src/HTTP/SignRequestHandler.ts
+++ b/src/HTTP/SignRequestHandler.ts
@@ -58,7 +58,7 @@ export default class SignRequestHandler {
             request.setData(requestData);
         } else if (options.isEncrypted) {
             const requestData: Buffer = request.data;
-            data = requestData.toString('binary');
+            data = requestData.toString("binary");
 
             request.setData(requestData);
         } else if (appendDataWhitelist.some(item => item === request.method)) {


### PR DESCRIPTION
These changes work with bunq's encryption endpoints according to my (non-extensive) testing.