### PR TITLE
fix: TypeScript detected type issue

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -119,7 +119,7 @@ export default class Session {
         const loadedStorage = await this.loadSession();
 
         // if there is no stored session but we have an key we setup a new keypair
-        if (loadedStorage === false && this.encryptionKey !== false) {
+        if (loadedStorage === false && this.encryptionKey) {
             // setup the required rsa keypair
             await this.setupKeypair(false, bitSize, ignoreCi);
         }


### PR DESCRIPTION
Fixes a trivial issue detected by TypeScript 3.7.

TypeScript detects the type of [this.encryptionKey](https://github.com/bunqCommunity/bunqJSClient/blob/3ec03fa4623029b8bcc2606eb4ab0528a4a6fbcb/src/Session.ts#L122) as `string | true`, which is correct because [line 107 in Session.ts](https://github.com/bunqCommunity/bunqJSClient/blob/3ec03fa4623029b8bcc2606eb4ab0528a4a6fbcb/src/Session.ts#L107) makes sure it's no longer `false`. To fix this error in TS, I have changed it to only guard against an empty API key.