### PR TITLE
Fix parseOauthUser  bug

### DIFF
--- a/src/BunqJSClient.ts
+++ b/src/BunqJSClient.ts
@@ -347,7 +347,7 @@ export default class BunqJSClient {
         this.Session.isOAuthKey = true;
 
         // set user info for granted by user
-        this.Session.userInfo["UserApiKey"] = grantedByUserParsed.info;
+        this.Session.userInfo["UserApiKey"] = userInfoParsed.info;
 
         return sessionTimeout;
     }


### PR DESCRIPTION
Save the useful UserApiKey instead of the UserPerson.id inside BunqJSClient.Session.userInfo["UserApiKey"]. The UserPerson.id couldn't be used to retrieve monetary accounts in the case of Oauth.